### PR TITLE
fix: align psdk release-js with Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Check psdk


### PR DESCRIPTION
## Summary
- change `release-js` in `dynamic-actions` back to Node 20
- keep the npm publish auth wiring from the previous fix intact
- remove the Node 24/runtime drift between `release.yml` and `check.yml`

## Why
The failing run for `v0.0.74-psdk` dies in `Release psdk-js` before publish. The `Check psdk` step installs `canvas@2.11.2`, and Node 24 requests a `node-v137` prebuilt binary that does not exist, then falls back to native compilation without the required system libraries. The existing `check-js` workflow already uses Node 20, and the same install path succeeds there.

## Validation
- `gh run view 23442287243 --repo 0xfe10/dynamic-actions --job 68196289355 --log`
- `docker run --rm -v /code/symphony/0xfe10/workspaces/DAM-36/psdk:/src -w /tmp node:24-bookworm bash -lc 'cp -a /src /tmp/psdk && cd /tmp/psdk/js && corepack enable && yarn install'`
- `docker run --rm -v /code/symphony/0xfe10/workspaces/DAM-36/psdk:/src -w /tmp node:20-bookworm bash -lc 'cp -a /src /tmp/psdk && cd /tmp/psdk/js && corepack enable && yarn install'`
- `git -C dynamic-actions diff --check`
- `ruby -e 'require "yaml"; release = YAML.load_file("/code/symphony/0xfe10/workspaces/DAM-36/dynamic-actions/.github/workflows/release.yml"); check = YAML.load_file("/code/symphony/0xfe10/workspaces/DAM-36/dynamic-actions/.github/workflows/check.yml"); abort unless release["jobs"]["release-js"]["steps"][2]["with"]["node-version"] == "20" && check["jobs"]["check-js"]["steps"][2]["with"]["node-version"] == "20"'`
